### PR TITLE
Update english strings

### DIFF
--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -6,15 +6,15 @@
   "editor": {
     "card": {
       "climate": {
-        "disable_window": "Disable window",
-        "disable_summer": "Disable summer",
-        "disable_eco": "Disable eco",
-        "disable_heat": "Disable heat",
-        "disable_off": "Disable off",
+        "disable_window": "Turn off the window open indicator",
+        "disable_summer": "Turn off the summer indicator",
+        "disable_eco": "Turn off the eco button",
+        "disable_heat": "Turn off the on/heat button",
+        "disable_off": "Turn off the off button",
         "disable_menu": "Disable menu",
-        "disable_battery_warning": "Disable battery warning",
-        "disable_buttons": "Disable plus/minus buttons",
-        "eco_temperature": "Eco temperature",
+        "disable_battery_warning": "Turn off the battery warning",
+        "disable_buttons": "Turn off the plus/minus buttons",
+        "eco_temperature": "Target temp for night/away/eco mode triggerd by ui button",
         "set_current_as_main": "Swap target with current temperature places"
       }
     }


### PR DESCRIPTION
This PR updates the English strings to match the more natural-sounding descriptions from the README. I prefer 'Disable' over 'Turn off,' but I'll leave that decision up to you. If we use 'Disable' i would also update the README for completeness. 

I came up with that proposal, because I believe that `Disable heat` and `Disable window` can be misleading. Whereby `Disable summer` pretty funny is :D
