### PR TITLE
fix(language): Correct JSON syntax in el.json

### DIFF
--- a/src/localize/languages/el.json
+++ b/src/localize/languages/el.json
@@ -1,7 +1,7 @@
 {
   "common": {
     "version": "Έκδοση",
-    "current": "Tρέχουσα"
+    "current": "Tρέχουσα",
     "current_humidity": "Τρέχουσα υγρασία",
     "current_temperature": "Τρέχουσα θερμοκρασία",
     "target_temperature": "Στόχος θερμοκρασίας"


### PR DESCRIPTION
The "current" key was missing comma at the end, leading to invalid JSON

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Greek localization file formatting to ensure proper parsing and display of Greek language strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->