### PR TITLE
fix: render full card layout when climate entity has no target temperature (fan_only/dry)

### DIFF
--- a/src/normal/climate-card.ts
+++ b/src/normal/climate-card.ts
@@ -54,6 +54,38 @@ function simpleDebounce<T extends (...args: any[]) => void>(fn: T, timeout = 300
   };
 }
 
+/**
+ * Shared state-color computation for both the main render path and the
+ * fallback (no-target-temperature) path.  Keeps the two branches in sync so
+ * overrides (window, preset_mode, off) can never diverge again.
+ */
+function computeStateColors(
+  stateObj: ClimateEntity,
+  window: boolean,
+  active: boolean,
+): { stateColor: string; actionColor: string | undefined } {
+  let stateColor = stateColorCss(stateObj);
+  let actionColor: string | undefined;
+  const action = stateObj.attributes.hvac_action;
+  if (action && action !== "idle" && action !== "off" && active) {
+    actionColor = stateColorCss(stateObj, CLIMATE_HVAC_ACTION_TO_MODE[action]);
+  }
+  const preset_mode = (stateObj.attributes as any)?.preset_mode;
+  if (window) {
+    actionColor = "var(--info-color)";
+    stateColor = "var(--info-color)";
+  } else if (preset_mode != null && preset_mode !== "none") {
+    const pre_color = getHvacModeColor(preset_mode);
+    stateColor = `rgb(${pre_color})`;
+    actionColor = `rgb(${pre_color})`;
+  }
+  if (stateObj.state === "off") {
+    stateColor = "var(--rgb-grey)";
+    actionColor = "var(--rgb-grey)";
+  }
+  return { stateColor, actionColor };
+}
+
 registerCustomCard({
   type: CLIMATE_CARD_NAME,
   name: "Better Thermostat Climate Card",
@@ -599,35 +631,12 @@ export class BetterThermostatUINormalCard extends MushroomBaseElement implements
     };
 
     if ((this._supportsTargetValue || this._supportsTargetRange) && available) {
-      const mode = this._stateObj.state;
-      const action = this._stateObj.attributes.hvac_action;
       const active = stateActive(this._stateObj);
 
       const containerSizeClass = this._sizeController.value
         ? ` ${this._sizeController.value}`
         : "";
-      let actionColor: string | undefined;
-      if (action && action !== "idle" && action !== "off" && active) {
-        actionColor = stateColorCss(
-          this._stateObj,
-          CLIMATE_HVAC_ACTION_TO_MODE[action]
-        );
-      }
-      let stateColor = stateColorCss(this._stateObj);
-      const preset_mode = (this._stateObj.attributes as any).preset_mode;
-      if (window) {
-        actionColor = "var(--info-color)";
-        stateColor = "var(--info-color)";
-      } else if (preset_mode != null && preset_mode !== 'none') {
-        const pre_color = getHvacModeColor(preset_mode);
-        stateColor = `rgb(${pre_color})`;
-        actionColor = `rgb(${pre_color})`;
-      }
-
-      if (mode === "off") {
-        stateColor = "var(--rgb-grey)";
-        actionColor = "var(--rgb-grey)";
-      }
+      const { stateColor, actionColor } = computeStateColors(this._stateObj, window, active);
 
 
       const lowColor = stateColorCss(this._stateObj, active ? "heat" : "off");
@@ -723,20 +732,7 @@ export class BetterThermostatUINormalCard extends MushroomBaseElement implements
       const containerSizeClass = this._sizeController.value
         ? ` ${this._sizeController.value}`
         : "";
-      let stateColor = stateColorCss(this._stateObj);
-      let actionColor: string | undefined;
-      const action = this._stateObj?.attributes.hvac_action;
-      if (action && action !== "idle" && action !== "off" && active) {
-        actionColor = stateColorCss(this._stateObj, CLIMATE_HVAC_ACTION_TO_MODE[action]);
-      }
-      if (window) {
-        actionColor = "var(--info-color)";
-        stateColor = "var(--info-color)";
-      }
-      if (this._stateObj?.state === "off") {
-        stateColor = "var(--rgb-grey)";
-        actionColor = "var(--rgb-grey)";
-      }
+      const { stateColor, actionColor } = computeStateColors(this._stateObj, window, active);
       const name = this._config.name || this._stateObj?.attributes.friendly_name || "";
       const controlMaxWidth = this._resizeController.value
         ? `${Math.min(this._resizeController.value, 320)}px`

--- a/src/normal/climate-card.ts
+++ b/src/normal/climate-card.ts
@@ -493,6 +493,9 @@ export class BetterThermostatUINormalCard extends MushroomBaseElement implements
       if (this._supportsTargetRange && !showCurrentAsPrimary) {
         return html`<div class="dual"> <button @click=${this._handleSelect} .target=${"low"} class="target-button ${classMap({ selected: this._selectTarget === "low" })}">${renderTarget(this._targetTemperature.low!, true)}</button><button @click=${this._handleSelect} .target=${"high"} class="target-button ${classMap({ selected: this._selectTarget === "high" })}">${renderTarget(this._targetTemperature.high!, true)}</button></div>`;
       }
+      // No target temperature supported (e.g. fan_only/dry mode) — show
+      // current temperature as the primary display if available.
+      if (currentTemp != null) return renderCurrent(currentTemp, true);
       return html`<p class="primary-state">${this.hass.formatEntityState(stateObj)}</p>`;
     };
 
@@ -710,10 +713,64 @@ export class BetterThermostatUINormalCard extends MushroomBaseElement implements
     `;
   }
 
-    return html`<ha-card><div class="container" style=${styleMap({})}>
-      <div class="info">${renderLabel()}${primary()}${secondary()}${renderHumidity()}</div>
-      ${available ? actionsSection() : nothing}
-    </div></ha-card>`;
+    // Fallback: entity does not support target temperature (e.g. fan_only/dry
+    // mode where the integration drops the `temperature` attribute), or entity
+    // is unavailable. Render the full card layout — title, color vars, wrapper,
+    // menu, actions — but without the circular slider and +/- buttons, since
+    // there is no setpoint to adjust. Show current temperature as primary.
+    {
+      const active = stateActive(this._stateObj);
+      const containerSizeClass = this._sizeController.value
+        ? ` ${this._sizeController.value}`
+        : "";
+      let stateColor = stateColorCss(this._stateObj);
+      let actionColor: string | undefined;
+      const action = this._stateObj?.attributes.hvac_action;
+      if (action && action !== "idle" && action !== "off" && active) {
+        actionColor = stateColorCss(this._stateObj, CLIMATE_HVAC_ACTION_TO_MODE[action]);
+      }
+      if (window) {
+        actionColor = "var(--info-color)";
+        stateColor = "var(--info-color)";
+      }
+      if (this._stateObj?.state === "off") {
+        stateColor = "var(--rgb-grey)";
+        actionColor = "var(--rgb-grey)";
+      }
+      const name = this._config.name || this._stateObj?.attributes.friendly_name || "";
+      const controlMaxWidth = this._resizeController.value
+        ? `${Math.min(this._resizeController.value, 320)}px`
+        : undefined;
+
+      return html`
+      <ha-card>
+        <p class="title">${name}</p>
+        <div class="container">
+          <div
+            class="bt-wrapper container${containerSizeClass}"
+            style=${styleMap({
+              "--state-color": stateColor ?? "var(--primary-text-color)",
+              "--action-color": actionColor ?? "",
+              maxWidth: controlMaxWidth,
+            })}
+          >
+            <div class="info">${renderLabel()}${primary()}${secondary()}${renderHumidity()}</div>
+          </div>
+        </div>
+        ${!this._config.disable_menu ? html`<ha-icon-button
+          class="more-info"
+          .label=${localize("ui.panel.lovelace.cards.show_more_info")}
+          .path=${mdiDotsVertical}
+          @click=${(e: Event) => {
+            e.stopPropagation();
+            this._handleMoreInfo();
+          }}
+          tabindex="0"
+        ></ha-icon-button>` : nothing}
+
+        ${available ? actionsSection() : nothing}
+      </ha-card>`;
+    }
   }
 
   private renderModeButton(mode: string) {


### PR DESCRIPTION
## Problem

When a climate entity is in `fan_only` or `dry` mode, the integration may drop the `temperature` and `target_temp_step` attributes and clear the `TARGET_TEMPERATURE` supported_features bit — since no setpoint is applicable while only the fan is running. This is spec-compliant per the [HA climate entity docs](https://developers.home-assistant.io/docs/core/entity/climate/): `HVACMode.FAN_ONLY` = *"The device only has the fan on. No heating or cooling taking place."*

The old fallback render path (line 713) was a bare `<ha-card><div class="container">` with just an info div — missing the title, color CSS variables, `bt-wrapper` class, more-info menu, and size-responsive container. This caused the card to render **garbled/incomplete** in these modes.

## Root Cause

The `render()` method has two paths:
1. **Full card** (line 598): `if (supportsTargetValue || supportsTargetRange) && available` → circular slider + title + colors + buttons + menu
2. **Fallback** (line 713): bare `<ha-card>` — no title, no wrapper, no colors, no menu, no size control

In `fan_only`, `_supportsTargetValue` returns `false` (the `temperature` key is absent from attributes), so the card falls to the bare fallback → garbled render.

## Fix

### Commit 1: `36a795e` — Initial fix
Unify the fallback path to render the **full card layout** — title, color CSS variables, `bt-wrapper` class, more-info menu, and action buttons — but **omit the circular slider and +/- buttons** since there is no setpoint to adjust. Show **current temperature as the primary display** when available.

### Commit 2: `da7793f` — Address CodeRabbit review
Extracted a shared `computeStateColors(stateObj, window, active)` helper used by **both** render paths. This fixes two issues:

1. **Bug**: The fallback path was missing the `preset_mode` color override that the main branch applies — entities in `fan_only`/`dry` with an active preset would show the wrong state color. Now fixed via the shared helper.
2. **Maintainability**: Both branches now share the same color logic (base → hvac_action → preset_mode → window → off), so they can never diverge again.

### Changes in `src/normal/climate-card.ts`:

1. **`primary()` function**: When no target temperature is supported, fall through to showing `currentTemp` as the big number (instead of just `formatEntityState`).

2. **`computeStateColors()` helper** (new, module-level): Shared state-color computation for both render paths.

3. **Main render path**: Replaced inline color logic with `computeStateColors()` call.

4. **Fallback render path**: Replaced the bare `<ha-card>` with the full card layout matching the main render path, using `computeStateColors()` for color logic.

## Verification

Verified on HA 2026.6.4 with Daikin Onecta (`daikin_onecta`) climate entities:

| Mode | `supported_features` | `TARGET_TEMPERATURE` bit | `temperature` attr | Before | After |
|---|---|---|---|---|---|
| `cool` | 441 | present | 27 | renders | renders |
| `off` | 953 | present | 25 | renders | renders |
| `fan_only` | 440 | absent | absent | garbled | renders (no slider, current temp as primary, correct preset color) |

`supported_features` 440 = `FAN_MODE | PRESET_MODE | SWING_MODE | TURN_OFF | TURN_ON` (no `TARGET_TEMPERATURE`).

Closes #282


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the main temperature display: when target temperature/ranges aren’t available, the card now shows the current temperature instead of generic state text.
  * Added a dedicated fallback layout for unsupported or unavailable thermostats, keeping the full card (title, details, and actions) visible while omitting the slider and setpoint controls.
  * Kept card styling consistent between the standard view and fallback scenarios for a more stable visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->