### PR TITLE
Update the Chinese translation\更新中文翻译

### DIFF
--- a/src/localize/languages/bg.json
+++ b/src/localize/languages/bg.json
@@ -9,16 +9,16 @@
   "editor": {
     "card": {
       "climate": {
+        "disable_humidity": "Изключване на показването на влажността",
         "disable_eco": "Деактивиране на показване на еко",
         "disable_menu": "Деактивиране на менюто",
         "disable_battery_warning": "Деактивиране на предупреждение за батерията",
         "disable_buttons": "Деактивиране на бутоните плюс/минус",
+        "show_temperature_control": "Показване на контрол на температурата",
+        "collapsible_controls": "Сгъваеми контроли",
         "show_current_as_primary": "Показване на текущата температура като основна",
         "show_secondary": "Показване на вторична информация",
         "prevent_interaction_on_scroll": "Предотвратяване на взаимодействие при превъртане",
-        "disable_humidity": "Изключване на показването на влажността",
-        "show_temperature_control": "Показване на контрол на температурата",
-        "collapsible_controls": "Сгъваеми контроли",
         "disable_connection_lost_warning": "Изключване на предупреждение за загубена връзка",
         "disable_degraded_warning": "Изключване на предупреждение за влошен режим",
         "low_battery_threshold": "Праг на предупреждение за изтощена батерия (%)",

--- a/src/localize/languages/ca.json
+++ b/src/localize/languages/ca.json
@@ -9,16 +9,16 @@
   "editor": {
     "card": {
       "climate": {
+        "disable_humidity": "Desactivar la visualització d'humitat",
         "disable_eco": "Desactivar indicador eco",
         "disable_menu": "Desactivar menú",
         "disable_battery_warning": "Desactivar advertència de bateria",
         "disable_buttons": "Desactivar botons de més/menys",
+        "show_temperature_control": "Mostra el control de temperatura",
+        "collapsible_controls": "Controls plegables",
         "show_current_as_primary": "Mostra la temperatura actual com a principal",
         "show_secondary": "Mostra informació secundària",
         "prevent_interaction_on_scroll": "Evitar la interacció en desplaçar-se",
-        "disable_humidity": "Desactivar la visualització d'humitat",
-        "show_temperature_control": "Mostra el control de temperatura",
-        "collapsible_controls": "Controls plegables",
         "disable_connection_lost_warning": "Desactiva avís de pèrdua de connexió",
         "disable_degraded_warning": "Desactiva avís de mode degradat",
         "low_battery_threshold": "Llindar d'avís de bateria baixa (%)",

--- a/src/localize/languages/cn.json
+++ b/src/localize/languages/cn.json
@@ -48,6 +48,9 @@
     "heating": "制热",
     "cooling_off": "关闭制冷",
     "heating_off": "关闭制热",
+    "degraded_mode": "降级模式",
+    "connection_lost": "连接丢失：{name}",
+    "low_battery": "电量低：{name}",
     "window_closed": "窗户关闭"
   }
 }

--- a/src/localize/languages/cn.json
+++ b/src/localize/languages/cn.json
@@ -23,22 +23,31 @@
         "prevent_interaction_on_scroll": "滚动时防止交互",
         "disable_connection_lost_warning": "关闭连接丢失警告",
         "disable_degraded_warning": "关闭降级模式警告",
+        "debug_battery": "调试：显示电池警告",
+        "debug_connection": "调试：显示连接丢失警告",
+        "debug_degraded": "调试：显示降级模式警告",
         "low_battery_threshold": "低电量警告阈值 (%)",
         "section_display": "显示",
+        "section_colors": "颜色",
+        "section_colors_helper": "覆盖暖通空调（HVAC）模式和预设的颜色。选择一个主题颜色，或清除选择器以恢复默认设置。",
         "section_interaction": "交互",
         "section_features": "功能",
-        "section_warnings": "警告"
+        "section_warnings": "警告",
+        "section_sensors": "外部传感器",
+        "window_sensor": "窗户传感器",
+        "humidity_sensor": "湿度传感器",
+        "not_bt_info": "所选实体并非Better Thermostat entity。该卡片仍可使用，但要显示窗户开启状态和湿度状态，您需要在“外部传感器”部分选择相应的传感器。"
       }
     }
   },
   "extra_states": {
-    "window_open": "窗口打开",
+    "window_open": "窗户打开",
     "eco": "节能",
     "summer": "夏季",
-    "cooling": "冷却",
-    "heating": "加热",
-    "cooling_off": "冷却关闭",
-    "heating_off": "加热关闭",
-    "window_closed": "窗口关闭"
+    "cooling": "制冷",
+    "heating": "制热",
+    "cooling_off": "关闭制冷",
+    "heating_off": "关闭制热",
+    "window_closed": "窗户关闭"
   }
 }

--- a/src/localize/languages/cn.json
+++ b/src/localize/languages/cn.json
@@ -9,16 +9,18 @@
   "editor": {
     "card": {
       "climate": {
+        "disable_humidity": "关闭湿度显示",
         "disable_eco": "禁用节能显示",
+        "disable_presets": "禁用预设按钮",
         "disable_menu": "禁用菜单",
         "disable_battery_warning": "禁用电池警告",
         "disable_buttons": "禁用加/减按钮",
+        "disable_all_buttons": "禁用所有按钮",
+        "show_temperature_control": "显示温度控制",
+        "collapsible_controls": "可折叠控制",
         "show_current_as_primary": "显示当前温度为主",
         "show_secondary": "显示次要信息",
         "prevent_interaction_on_scroll": "滚动时防止交互",
-        "disable_humidity": "关闭湿度显示",
-        "show_temperature_control": "显示温度控制",
-        "collapsible_controls": "可折叠控制",
         "disable_connection_lost_warning": "关闭连接丢失警告",
         "disable_degraded_warning": "关闭降级模式警告",
         "low_battery_threshold": "低电量警告阈值 (%)",

--- a/src/localize/languages/cs.json
+++ b/src/localize/languages/cs.json
@@ -9,16 +9,16 @@
   "editor": {
     "card": {
       "climate": {
+        "disable_humidity": "Zakázat zobrazení vlhkosti",
         "disable_eco": "Zakázat eco",
         "disable_menu": "Zakázat menu",
         "disable_battery_warning": "Zakázat upozornění baterie",
         "disable_buttons": "Zakázat tlačítka plus/minus",
+        "show_temperature_control": "Zobrazit ovládání teploty",
+        "collapsible_controls": "Sbalitelné ovládání",
         "show_current_as_primary": "Zobrazit aktuální teplotu jako hlavní",
         "show_secondary": "Zobrazit sekundární informace",
         "prevent_interaction_on_scroll": "Zabránit interakci při posouvání",
-        "disable_humidity": "Zakázat zobrazení vlhkosti",
-        "show_temperature_control": "Zobrazit ovládání teploty",
-        "collapsible_controls": "Sbalitelné ovládání",
         "disable_connection_lost_warning": "Vypnout upozornění na ztrátu spojení",
         "disable_degraded_warning": "Vypnout upozornění na zhoršený režim",
         "low_battery_threshold": "Práh upozornění na nízkou baterii (%)",

--- a/src/localize/languages/da.json
+++ b/src/localize/languages/da.json
@@ -9,16 +9,16 @@
   "editor": {
     "card": {
       "climate": {
+        "disable_humidity": "Deaktiver fugtighedsvisning",
         "disable_eco": "Deaktiver Eco indikator",
         "disable_menu": "Deaktiver menu",
         "disable_battery_warning": "Deaktiver batteriadvarsel",
         "disable_buttons": "Deaktiver plus/minus knapper",
+        "show_temperature_control": "Vis temperaturkontrol",
+        "collapsible_controls": "Sammenklappelige kontroller",
         "show_current_as_primary": "Vis nuværende temperatur som primær",
         "show_secondary": "Vis sekundær information",
         "prevent_interaction_on_scroll": "Forhindre interaktion ved scrolling",
-        "disable_humidity": "Deaktiver fugtighedsvisning",
-        "show_temperature_control": "Vis temperaturkontrol",
-        "collapsible_controls": "Sammenklappelige kontroller",
         "disable_connection_lost_warning": "Deaktiver advarsel om mistet forbindelse",
         "disable_degraded_warning": "Deaktiver advarsel om forringet tilstand",
         "low_battery_threshold": "Grænse for advarsel om lavt batteri (%)",

--- a/src/localize/languages/de.json
+++ b/src/localize/languages/de.json
@@ -9,18 +9,18 @@
   "editor": {
     "card": {
       "climate": {
+        "disable_humidity": "Deaktiviere die Anzeige der Luftfeuchtigkeit",
         "disable_eco": "Eco-Anzeige deaktivieren",
         "disable_presets": "Presets-Button deaktivieren",
         "disable_menu": "Menü deaktivieren",
         "disable_battery_warning": "Batterie-Warnung deaktivieren",
         "disable_buttons": "Plus/Minus Buttons deaktivieren",
         "disable_all_buttons": "Alle Buttons deaktivieren",
+        "show_temperature_control": "Temperaturregelung anzeigen",
+        "collapsible_controls": "Einklappbare Steuerung",
         "show_current_as_primary": "Aktuelle Temperatur als primär anzeigen",
         "show_secondary": "Sekundäre Informationen anzeigen",
         "prevent_interaction_on_scroll": "Interaktion beim Scrollen verhindern",
-        "disable_humidity": "Deaktiviere die Anzeige der Luftfeuchtigkeit",
-        "show_temperature_control": "Temperaturregelung anzeigen",
-        "collapsible_controls": "Einklappbare Steuerung",
         "disable_connection_lost_warning": "Verbindungsverlust-Warnung deaktivieren",
         "disable_degraded_warning": "Warnung für eingeschränkten Modus deaktivieren",
         "debug_battery": "Debug: Batterie-Warnung anzeigen",

--- a/src/localize/languages/el.json
+++ b/src/localize/languages/el.json
@@ -9,16 +9,16 @@
   "editor": {
     "card": {
       "climate": {
+        "disable_humidity": "Απενεργοποίηση εμφάνισης υγρασίας",
         "disable_eco": "Απενεργοποίηση ένδειξης Eco",
         "disable_menu": "Απενεργοποίηση μενού",
         "disable_battery_warning": "Απενεργοποίηση προειδοποίησης μπαταρίας",
         "disable_buttons": "Απενεργοποίηση κουμπιών Plus/Minus",
+        "show_temperature_control": "Εμφάνιση ελέγχου θερμοκρασίας",
+        "collapsible_controls": "Πτυσσόμενα στοιχεία ελέγχου",
         "show_current_as_primary": "Εμφάνιση τρέχουσας θερμοκρασίας ως κύρια",
         "show_secondary": "Εμφάνιση δευτερευουσών πληροφοριών",
         "prevent_interaction_on_scroll": "Αποτροπή αλληλεπίδρασης κατά την κύλιση",
-        "disable_humidity": "Απενεργοποίηση εμφάνισης υγρασίας",
-        "show_temperature_control": "Εμφάνιση ελέγχου θερμοκρασίας",
-        "collapsible_controls": "Πτυσσόμενα στοιχεία ελέγχου",
         "disable_connection_lost_warning": "Απενεργοποίηση προειδοποίησης απώλειας σύνδεσης",
         "disable_degraded_warning": "Απενεργοποίηση προειδοποίησης υποβαθμισμένης λειτουργίας",
         "low_battery_threshold": "Όριο προειδοποίησης χαμηλής μπαταρίας (%)",

--- a/src/localize/languages/es.json
+++ b/src/localize/languages/es.json
@@ -9,16 +9,16 @@
   "editor": {
     "card": {
       "climate": {
+        "disable_humidity": "Desactivar la visualización de humedad",
         "disable_eco": "Deshabilitar eco",
         "disable_menu": "Deshabilitar menú",
         "disable_battery_warning": "Deshabilitar alerta de batería",
         "disable_buttons": "Deshabilitar botones más/menos",
+        "show_temperature_control": "Mostrar control de temperatura",
+        "collapsible_controls": "Controles plegables",
         "show_current_as_primary": "Mostrar temperatura actual como principal",
         "show_secondary": "Mostrar información secundaria",
         "prevent_interaction_on_scroll": "Evitar interacción al desplazarse",
-        "disable_humidity": "Desactivar la visualización de humedad",
-        "show_temperature_control": "Mostrar control de temperatura",
-        "collapsible_controls": "Controles plegables",
         "disable_connection_lost_warning": "Desactivar aviso de pérdida de conexión",
         "disable_degraded_warning": "Desactivar aviso de modo degradado",
         "low_battery_threshold": "Umbral de aviso de batería baja (%)",

--- a/src/localize/languages/fi.json
+++ b/src/localize/languages/fi.json
@@ -9,16 +9,16 @@
   "editor": {
     "card": {
       "climate": {
+        "disable_humidity": "Poista kosteusnäyttö käytöstä",
         "disable_eco": "Poista Eco -ilmoitus käytöstä",
         "disable_menu": "Poista valikko käytöstä",
         "disable_battery_warning": "Poista akun varoitus käytöstä",
         "disable_buttons": "Poista plus/miinus -painikkeet käytöstä",
+        "show_temperature_control": "Näytä lämpötilan säätö",
+        "collapsible_controls": "Kokoon taittuvat säätimet",
         "show_current_as_primary": "Näytä nykyinen lämpötila ensisijaisena",
         "show_secondary": "Näytä toissijaiset tiedot",
         "prevent_interaction_on_scroll": "Estä vuorovaikutus vieritettäessä",
-        "disable_humidity": "Poista kosteusnäyttö käytöstä",
-        "show_temperature_control": "Näytä lämpötilan säätö",
-        "collapsible_controls": "Kokoon taittuvat säätimet",
         "disable_connection_lost_warning": "Poista yhteyden katkeamisen varoitus käytöstä",
         "disable_degraded_warning": "Poista heikentyneen tilan varoitus käytöstä",
         "low_battery_threshold": "Alhaisen akun varoituskynnys (%)",

--- a/src/localize/languages/fr.json
+++ b/src/localize/languages/fr.json
@@ -9,16 +9,16 @@
   "editor": {
     "card": {
       "climate": {
+        "disable_humidity": "Désactiver l'affichage de l'humidité",
         "disable_eco": "Désactiver mode Éco",
         "disable_menu": "Désactiver le menu",
         "disable_battery_warning": "Désactiver l'avertissement de batterie",
         "disable_buttons": "Désactiver les boutons plus/moins",
+        "show_temperature_control": "Afficher le contrôle de température",
+        "collapsible_controls": "Contrôles pliables",
         "show_current_as_primary": "Afficher la température actuelle comme principale",
         "show_secondary": "Afficher les informations secondaires",
         "prevent_interaction_on_scroll": "Empêcher l'interaction lors du défilement",
-        "disable_humidity": "Désactiver l'affichage de l'humidité",
-        "show_temperature_control": "Afficher le contrôle de température",
-        "collapsible_controls": "Contrôles pliables",
         "disable_connection_lost_warning": "Désactiver avertissement perte de connexion",
         "disable_degraded_warning": "Désactiver avertissement mode dégradé",
         "low_battery_threshold": "Seuil avertissement batterie faible (%)",

--- a/src/localize/languages/gl.json
+++ b/src/localize/languages/gl.json
@@ -6,11 +6,11 @@
   "editor": {
     "card": {
       "climate": {
+        "disable_humidity": "Desactivar visualización de humidade",
         "disable_eco": "Desactivar eco",
         "disable_menu": "Desactivar menú",
         "disable_battery_warning": "Desactivar alerta de batería",
         "disable_buttons": "Desactivar botóns máis/menos",
-        "disable_humidity": "Desactivar visualización de humidade",
         "show_temperature_control": "Mostrar control de temperatura",
         "collapsible_controls": "Controis pregables",
         "disable_connection_lost_warning": "Desactivar aviso de perda de conexión",

--- a/src/localize/languages/hu.json
+++ b/src/localize/languages/hu.json
@@ -9,16 +9,16 @@
   "editor": {
     "card": {
       "climate": {
+        "disable_humidity": "Páratartalom megjelenítés kikapcsolása",
         "disable_eco": "Eco kikapcsolás",
         "disable_menu": "Menü letiltása",
         "disable_battery_warning": "Akkumulátor figyelmeztetés letiltása",
         "disable_buttons": "Plusz/mínusz gombok letiltása",
+        "show_temperature_control": "Hőmérséklet-szabályzó megjelenítése",
+        "collapsible_controls": "Összecsukható vezérlők",
         "show_current_as_primary": "Jelenlegi hőmérséklet megjelenítése elsődlegesként",
         "show_secondary": "Másodlagos információk megjelenítése",
         "prevent_interaction_on_scroll": "Interakció megakadályozása görgetéskor",
-        "disable_humidity": "Páratartalom megjelenítés kikapcsolása",
-        "show_temperature_control": "Hőmérséklet-szabályzó megjelenítése",
-        "collapsible_controls": "Összecsukható vezérlők",
         "disable_connection_lost_warning": "Kapcsolatvesztés figyelmeztetés kikapcsolása",
         "disable_degraded_warning": "Korlátozott mód figyelmeztetés kikapcsolása",
         "low_battery_threshold": "Alacsony akkumulátor figyelmeztetési küszöb (%)",

--- a/src/localize/languages/it.json
+++ b/src/localize/languages/it.json
@@ -9,16 +9,16 @@
   "editor": {
     "card": {
       "climate": {
+        "disable_humidity": "Disattiva visualizzazione umidità",
         "disable_eco": "Disabilita tasto eco",
         "disable_menu": "Disabilita menu",
         "disable_battery_warning": "Disabilita avviso batteria",
         "disable_buttons": "Disabilita pulsanti più/meno",
+        "show_temperature_control": "Mostra controllo temperatura",
+        "collapsible_controls": "Controlli comprimibili",
         "show_current_as_primary": "Mostra temperatura attuale come principale",
         "show_secondary": "Mostra informazioni secondarie",
         "prevent_interaction_on_scroll": "Prevenire interazione durante lo scorrimento",
-        "disable_humidity": "Disattiva visualizzazione umidità",
-        "show_temperature_control": "Mostra controllo temperatura",
-        "collapsible_controls": "Controlli comprimibili",
         "disable_connection_lost_warning": "Disabilita avviso perdita connessione",
         "disable_degraded_warning": "Disabilita avviso modalità degradata",
         "low_battery_threshold": "Soglia avviso batteria scarica (%)",

--- a/src/localize/languages/lv.json
+++ b/src/localize/languages/lv.json
@@ -9,16 +9,16 @@
   "editor": {
     "card": {
       "climate": {
+        "disable_humidity": "Izslēgt mitruma rādījumu",
         "disable_eco": "Atspējot ekonomisko režīmu",
         "disable_menu": "Atspējot izvēlni",
         "disable_battery_warning": "Atspējot baterijas brīdinājumu",
         "disable_buttons": "Atspējot plus/mīnus pogas",
+        "show_temperature_control": "Rādīt temperatūras kontroli",
+        "collapsible_controls": "Salocāmas vadīklas",
         "show_current_as_primary": "Rādīt pašreizējo temperatūru kā galveno",
         "show_secondary": "Rādīt sekundāro informāciju",
         "prevent_interaction_on_scroll": "Novērst mijiedarbību ritinot",
-        "disable_humidity": "Izslēgt mitruma rādījumu",
-        "show_temperature_control": "Rādīt temperatūras kontroli",
-        "collapsible_controls": "Salocāmas vadīklas",
         "disable_connection_lost_warning": "Izslēgt savienojuma zaudēšanas brīdinājumu",
         "disable_degraded_warning": "Izslēgt pasliktināta režīma brīdinājumu",
         "low_battery_threshold": "Zemas baterijas brīdinājuma slieksnis (%)",

--- a/src/localize/languages/nl.json
+++ b/src/localize/languages/nl.json
@@ -9,16 +9,16 @@
   "editor": {
     "card": {
       "climate": {
+        "disable_humidity": "Vochtigheidsweergave uitschakelen",
         "disable_eco": "Eco-weergave uitschakelen",
         "disable_menu": "Menu uitschakelen",
         "disable_battery_warning": "Batterijwaarschuwing uitschakelen",
         "disable_buttons": "Plus/min-knoppen uitschakelen",
+        "show_temperature_control": "Temperatuurregeling tonen",
+        "collapsible_controls": "Inklapbare bedieningselementen",
         "show_current_as_primary": "Toon huidige temperatuur als primair",
         "show_secondary": "Toon secundaire informatie",
         "prevent_interaction_on_scroll": "Voorkom interactie tijdens scrollen",
-        "disable_humidity": "Vochtigheidsweergave uitschakelen",
-        "show_temperature_control": "Temperatuurregeling tonen",
-        "collapsible_controls": "Inklapbare bedieningselementen",
         "disable_connection_lost_warning": "Waarschuwing verbinding verbroken uitschakelen",
         "disable_degraded_warning": "Waarschuwing verminderde modus uitschakelen",
         "low_battery_threshold": "Drempel batterijwaarschuwing (%)",

--- a/src/localize/languages/no.json
+++ b/src/localize/languages/no.json
@@ -9,16 +9,16 @@
   "editor": {
     "card": {
       "climate": {
+        "disable_humidity": "Deaktiver fuktighetsvisning",
         "disable_eco": "Deaktiver eco visning",
         "disable_menu": "Deaktiver meny",
         "disable_battery_warning": "Deaktiver batterivarsel",
         "disable_buttons": "Deaktiver pluss/minus knapper",
+        "show_temperature_control": "Vis temperaturkontroll",
+        "collapsible_controls": "Sammenleggbare kontroller",
         "show_current_as_primary": "Vis nåværende temperatur som primær",
         "show_secondary": "Vis sekundær informasjon",
         "prevent_interaction_on_scroll": "Forhindre interaksjon ved rulling",
-        "disable_humidity": "Deaktiver fuktighetsvisning",
-        "show_temperature_control": "Vis temperaturkontroll",
-        "collapsible_controls": "Sammenleggbare kontroller",
         "disable_connection_lost_warning": "Deaktiver advarsel om tapt tilkobling",
         "disable_degraded_warning": "Deaktiver advarsel om degradert modus",
         "low_battery_threshold": "Terskel for advarsel om lavt batteri (%)",

--- a/src/localize/languages/pl.json
+++ b/src/localize/languages/pl.json
@@ -9,28 +9,28 @@
   "editor": {
     "card": {
       "climate": {
+        "disable_humidity": "Wyłącz wyświetlanie wilgotności",
         "disable_eco": "Wyłącz przycisk trybu eko",
+        "disable_presets": "Wyłącz przyciski ustawień predefiniowanych",
         "disable_menu": "Wyłącz menu",
         "disable_battery_warning": "Wyłącz ostrzeżenie o baterii",
         "disable_buttons": "Wyłącz przyciski plus/minus",
+        "disable_all_buttons": "Wyłącz wszystkie przyciski",
+        "show_temperature_control": "Pokaż suwak temperatury",
+        "collapsible_controls": "Rozwijane menu ustawień",
         "show_current_as_primary": "Pokaż aktualną temperaturę jako główną",
         "show_secondary": "Pokaż dodatkowe informacje",
         "prevent_interaction_on_scroll": "Zapobiegaj interakcji podczas przewijania",
-        "disable_humidity": "Wyłącz wyświetlanie wilgotności",
-        "show_temperature_control": "Pokaż suwak temperatury",
-        "collapsible_controls": "Rozwijane menu ustawień",
         "disable_connection_lost_warning": "Wyłącz ostrzeżenie o utracie połączenia",
         "disable_degraded_warning": "Wyłącz ostrzeżenie o trybie ograniczonym",
+        "debug_battery": "Debug: Pokaż ostrzeżenie baterii",
+        "debug_connection": "Debug: Pokaż ostrzeżenie o utracie połączenia",
+        "debug_degraded": "Debug: Pokaż ostrzeżenie o trybie ograniczonym",
         "low_battery_threshold": "Próg ostrzeżenia o niskim stanie baterii (%)",
         "section_display": "Wyświetlanie",
         "section_interaction": "Interakcja",
         "section_features": "Funkcje",
         "section_warnings": "Ostrzeżenia",
-        "disable_presets": "Wyłącz przyciski ustawień predefiniowanych",
-        "disable_all_buttons": "Wyłącz wszystkie przyciski",
-        "debug_battery": "Debug: Pokaż ostrzeżenie baterii",
-        "debug_connection": "Debug: Pokaż ostrzeżenie o utracie połączenia",
-        "debug_degraded": "Debug: Pokaż ostrzeżenie o trybie ograniczonym",
         "section_sensors": "Czujniki zewnętrzne",
         "window_sensor": "Czujnik otwarcia okna",
         "humidity_sensor": "Czujnik wilgotności",
@@ -46,9 +46,9 @@
     "heating": "Grzanie",
     "cooling_off": "Chłodzenie wyłączone",
     "heating_off": "Grzanie wyłączone",
-    "window_closed": "Okno zamknięte",
     "degraded_mode": "Tryb ograniczony",
     "connection_lost": "Połączenie utracone: {name}",
-    "low_battery": "Niski poziom baterii: {name}"
+    "low_battery": "Niski poziom baterii: {name}",
+    "window_closed": "Okno zamknięte"
   }
 }

--- a/src/localize/languages/pt.json
+++ b/src/localize/languages/pt.json
@@ -9,16 +9,16 @@
   "editor": {
     "card": {
       "climate": {
+        "disable_humidity": "Desativar exibição de humidade",
         "disable_eco": "Desactivar Eco",
         "disable_menu": "Desativar menu",
         "disable_battery_warning": "Desativar aviso de bateria",
         "disable_buttons": "Desativar botões de mais/menos",
+        "show_temperature_control": "Mostrar controlo de temperatura",
+        "collapsible_controls": "Controlos recolhíveis",
         "show_current_as_primary": "Mostrar temperatura atual como principal",
         "show_secondary": "Mostrar informações secundárias",
         "prevent_interaction_on_scroll": "Prevenir interação ao rolar",
-        "disable_humidity": "Desativar exibição de humidade",
-        "show_temperature_control": "Mostrar controlo de temperatura",
-        "collapsible_controls": "Controlos recolhíveis",
         "disable_connection_lost_warning": "Desativar aviso de perda de ligação",
         "disable_degraded_warning": "Desativar aviso de modo degradado",
         "low_battery_threshold": "Limiar de aviso de bateria fraca (%)",

--- a/src/localize/languages/ro.json
+++ b/src/localize/languages/ro.json
@@ -9,16 +9,16 @@
   "editor": {
     "card": {
       "climate": {
+        "disable_humidity": "Dezactivează afișarea umidității",
         "disable_eco": "Dezactivează eco",
         "disable_menu": "Dezactivează meniul",
         "disable_battery_warning": "Dezactivează avertizarea bateriei",
         "disable_buttons": "Dezactivează butoanele plus/minus",
+        "show_temperature_control": "Afișează controlul temperaturii",
+        "collapsible_controls": "Controale pliabile",
         "show_current_as_primary": "Afișează temperatura curentă ca principală",
         "show_secondary": "Afișează informații secundare",
         "prevent_interaction_on_scroll": "Previne interacțiunea la derulare",
-        "disable_humidity": "Dezactivează afișarea umidității",
-        "show_temperature_control": "Afișează controlul temperaturii",
-        "collapsible_controls": "Controale pliabile",
         "disable_connection_lost_warning": "Dezactivează avertismentul de pierdere a conexiunii",
         "disable_degraded_warning": "Dezactivează avertismentul de mod degradat",
         "low_battery_threshold": "Prag avertisment baterie descărcată (%)",

--- a/src/localize/languages/ru.json
+++ b/src/localize/languages/ru.json
@@ -9,16 +9,16 @@
   "editor": {
     "card": {
       "climate": {
+        "disable_humidity": "Отключить отображение влажности",
         "disable_eco": "Отключить режим eco",
         "disable_menu": "Отключить меню",
         "disable_battery_warning": "Отключить предупреждение о разряде батареи",
         "disable_buttons": "Отключить кнопку плюс/минус",
+        "show_temperature_control": "Показать управление температурой",
+        "collapsible_controls": "Сворачиваемые элементы управления",
         "show_current_as_primary": "Показывать текущую температуру как основную",
         "show_secondary": "Показывать вторичную информацию",
         "prevent_interaction_on_scroll": "Предотвратить взаимодействие при прокрутке",
-        "disable_humidity": "Отключить отображение влажности",
-        "show_temperature_control": "Показать управление температурой",
-        "collapsible_controls": "Сворачиваемые элементы управления",
         "disable_connection_lost_warning": "Отключить предупреждение о потере соединения",
         "disable_degraded_warning": "Отключить предупреждение о деградированном режиме",
         "low_battery_threshold": "Порог предупреждения о низком заряде (%)",

--- a/src/localize/languages/sk.json
+++ b/src/localize/languages/sk.json
@@ -9,16 +9,16 @@
   "editor": {
     "card": {
       "climate": {
+        "disable_humidity": "Vypnúť zobrazenie vlhkosti",
         "disable_eco": "Zakázať eco",
         "disable_menu": "Zakázať menu",
         "disable_battery_warning": "Zakázať upozornenie na batériu",
         "disable_buttons": "Zakázať plus/mínus tlačidlá",
+        "show_temperature_control": "Zobraziť ovládanie teploty",
+        "collapsible_controls": "Skladateľné ovládanie",
         "show_current_as_primary": "Zobraziť aktuálnu teplotu ako hlavnú",
         "show_secondary": "Zobraziť sekundárne informácie",
         "prevent_interaction_on_scroll": "Zabrániť interakcii pri posúvaní",
-        "disable_humidity": "Vypnúť zobrazenie vlhkosti",
-        "show_temperature_control": "Zobraziť ovládanie teploty",
-        "collapsible_controls": "Skladateľné ovládanie",
         "disable_connection_lost_warning": "Vypnúť upozornenie na stratu spojenia",
         "disable_degraded_warning": "Vypnúť upozornenie na zhoršený režim",
         "low_battery_threshold": "Prah varovania o nízkej batérii (%)",

--- a/src/localize/languages/sl.json
+++ b/src/localize/languages/sl.json
@@ -9,16 +9,16 @@
   "editor": {
     "card": {
       "climate": {
+        "disable_humidity": "Onemogoči prikaz vlažnosti",
         "disable_eco": "Onemogoči prikaz eco",
         "disable_menu": "Onemogoči meni",
         "disable_battery_warning": "Onemogoči opozorilo o bateriji",
         "disable_buttons": "Onemogoči gumbe plus/minus",
+        "show_temperature_control": "Prikaži nadzor temperature",
+        "collapsible_controls": "Zložljivi kontrolniki",
         "show_current_as_primary": "Prikaži trenutno temperaturo kot primarno",
         "show_secondary": "Prikaži sekundarne informacije",
         "prevent_interaction_on_scroll": "Prepreči interakcijo med drsenjem",
-        "disable_humidity": "Onemogoči prikaz vlažnosti",
-        "show_temperature_control": "Prikaži nadzor temperature",
-        "collapsible_controls": "Zložljivi kontrolniki",
         "disable_connection_lost_warning": "Onemogoči opozorilo o izgubi povezave",
         "disable_degraded_warning": "Onemogoči opozorilo o zmanjšanem načinu",
         "low_battery_threshold": "Prag opozorila za nizko baterijo (%)",

--- a/src/localize/languages/sv.json
+++ b/src/localize/languages/sv.json
@@ -9,16 +9,16 @@
   "editor": {
     "card": {
       "climate": {
+        "disable_humidity": "Inaktivera fuktighetsvisning",
         "disable_eco": "Inaktivera eco visning",
         "disable_menu": "Inaktivera meny",
         "disable_battery_warning": "Inaktivera batterivarning",
         "disable_buttons": "Inaktivera plus/minus knappar",
+        "show_temperature_control": "Visa temperaturkontroll",
+        "collapsible_controls": "Ihopfällbara kontroller",
         "show_current_as_primary": "Visa aktuell temperatur som primär",
         "show_secondary": "Visa sekundär information",
         "prevent_interaction_on_scroll": "Förhindra interaktion vid rullning",
-        "disable_humidity": "Inaktivera fuktighetsvisning",
-        "show_temperature_control": "Visa temperaturkontroll",
-        "collapsible_controls": "Ihopfällbara kontroller",
         "disable_connection_lost_warning": "Inaktivera varning för tappad anslutning",
         "disable_degraded_warning": "Inaktivera varning för försämrat läge",
         "low_battery_threshold": "Tröskelvärde för varning om låg batterinivå (%)",

--- a/src/localize/languages/tr.json
+++ b/src/localize/languages/tr.json
@@ -9,16 +9,16 @@
   "editor": {
     "card": {
       "climate": {
+        "disable_humidity": "Nem gösterimini kapat",
         "disable_eco": "Eco'yu devre dışı bırak",
         "disable_menu": "Menüyü devre dışı bırak",
         "disable_battery_warning": "Pil uyarısını devre dışı bırak",
         "disable_buttons": "Artı/eksi düğmelerini devre dışı bırak",
+        "show_temperature_control": "Sıcaklık kontrolünü göster",
+        "collapsible_controls": "Daraltılabilir kontroller",
         "show_current_as_primary": "Mevcut sıcaklığı birincil olarak göster",
         "show_secondary": "İkincil bilgileri göster",
         "prevent_interaction_on_scroll": "Kaydırma sırasında etkileşimi önle",
-        "disable_humidity": "Nem gösterimini kapat",
-        "show_temperature_control": "Sıcaklık kontrolünü göster",
-        "collapsible_controls": "Daraltılabilir kontroller",
         "disable_connection_lost_warning": "Bağlantı kesildi uyarısını kapat",
         "disable_degraded_warning": "Düşük mod uyarısını kapat",
         "low_battery_threshold": "Düşük pil uyarı eşiği (%)",

--- a/src/localize/languages/uk.json
+++ b/src/localize/languages/uk.json
@@ -9,16 +9,16 @@
   "editor": {
     "card": {
       "climate": {
+        "disable_humidity": "Вимкнути відображення вологості",
         "disable_eco": "Прибрати еко",
         "disable_menu": "Прибрати меню",
         "disable_battery_warning": "Прибрати попередження про акумулятор",
         "disable_buttons": "Прибрати кнопки плюс/мінус",
+        "show_temperature_control": "Показати контроль температури",
+        "collapsible_controls": "Згортані елементи керування",
         "show_current_as_primary": "Показувати поточну температуру як основну",
         "show_secondary": "Показувати вторинну інформацію",
         "prevent_interaction_on_scroll": "Запобігати взаємодії при прокручуванні",
-        "disable_humidity": "Вимкнути відображення вологості",
-        "show_temperature_control": "Показати контроль температури",
-        "collapsible_controls": "Згортані елементи керування",
         "disable_connection_lost_warning": "Вимкнути попередження про втрату з'єднання",
         "disable_degraded_warning": "Вимкнути попередження про деградований режим",
         "low_battery_threshold": "Поріг попередження про низький заряд (%)",


### PR DESCRIPTION
Added some missing Chinese translations and corrected some incorrect translations and grammatical errors.
添加了部分缺少的中文翻译，并修正了部分不正确的翻译和语病。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * Standardized the display order of climate editor toggle labels (including humidity and temperature control options) across many supported languages.
  * Updated Chinese climate editor translations by adding new control labels, debug warnings, color/external sensor text, and guidance, plus adjusted a set of extra state labels.
  * Refined select Chinese window/cooling-heating related wording for clearer state naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->