### PR TITLE
Fix/disable slider option

### DIFF
--- a/src/localize/languages/bg.json
+++ b/src/localize/languages/bg.json
@@ -14,6 +14,7 @@
         "disable_menu": "Деактивиране на менюто",
         "disable_battery_warning": "Деактивиране на предупреждение за батерията",
         "disable_buttons": "Деактивиране на бутоните плюс/минус",
+		"disable_slider": "Деактивиране на плъзгача",
         "show_temperature_control": "Показване на контрол на температурата",
         "collapsible_controls": "Сгъваеми контроли",
         "show_current_as_primary": "Показване на текущата температура като основна",

--- a/src/localize/languages/ca.json
+++ b/src/localize/languages/ca.json
@@ -14,6 +14,7 @@
         "disable_menu": "Desactivar menú",
         "disable_battery_warning": "Desactivar advertència de bateria",
         "disable_buttons": "Desactivar botons de més/menys",
+		"disable_slider": "Desactivar el lliscador",
         "show_temperature_control": "Mostra el control de temperatura",
         "collapsible_controls": "Controls plegables",
         "show_current_as_primary": "Mostra la temperatura actual com a principal",

--- a/src/localize/languages/cn.json
+++ b/src/localize/languages/cn.json
@@ -15,6 +15,7 @@
         "disable_menu": "禁用菜单",
         "disable_battery_warning": "禁用电池警告",
         "disable_buttons": "禁用加/减按钮",
+		"disable_slider": "禁用滑块",
         "disable_all_buttons": "禁用所有按钮",
         "show_temperature_control": "显示温度控制",
         "collapsible_controls": "可折叠控制",

--- a/src/localize/languages/cs.json
+++ b/src/localize/languages/cs.json
@@ -14,6 +14,7 @@
         "disable_menu": "Zakázat menu",
         "disable_battery_warning": "Zakázat upozornění baterie",
         "disable_buttons": "Zakázat tlačítka plus/minus",
+		"disable_slider": "Zakázat posuvník",
         "show_temperature_control": "Zobrazit ovládání teploty",
         "collapsible_controls": "Sbalitelné ovládání",
         "show_current_as_primary": "Zobrazit aktuální teplotu jako hlavní",

--- a/src/localize/languages/da.json
+++ b/src/localize/languages/da.json
@@ -14,6 +14,7 @@
         "disable_menu": "Deaktiver menu",
         "disable_battery_warning": "Deaktiver batteriadvarsel",
         "disable_buttons": "Deaktiver plus/minus knapper",
+		"disable_slider": "Deaktiver skyder",
         "show_temperature_control": "Vis temperaturkontrol",
         "collapsible_controls": "Sammenklappelige kontroller",
         "show_current_as_primary": "Vis nuværende temperatur som primær",

--- a/src/localize/languages/de.json
+++ b/src/localize/languages/de.json
@@ -15,6 +15,7 @@
         "disable_menu": "Menü deaktivieren",
         "disable_battery_warning": "Batterie-Warnung deaktivieren",
         "disable_buttons": "Plus/Minus Buttons deaktivieren",
+		"disable_slider": "Regler deaktivieren",
         "disable_all_buttons": "Alle Buttons deaktivieren",
         "show_temperature_control": "Temperaturregelung anzeigen",
         "collapsible_controls": "Einklappbare Steuerung",

--- a/src/localize/languages/el.json
+++ b/src/localize/languages/el.json
@@ -14,6 +14,7 @@
         "disable_menu": "Απενεργοποίηση μενού",
         "disable_battery_warning": "Απενεργοποίηση προειδοποίησης μπαταρίας",
         "disable_buttons": "Απενεργοποίηση κουμπιών Plus/Minus",
+		"disable_slider": "Απενεργοποίηση ρυθμιστικού",
         "show_temperature_control": "Εμφάνιση ελέγχου θερμοκρασίας",
         "collapsible_controls": "Πτυσσόμενα στοιχεία ελέγχου",
         "show_current_as_primary": "Εμφάνιση τρέχουσας θερμοκρασίας ως κύρια",

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -15,6 +15,7 @@
         "disable_menu": "Disable menu",
         "disable_battery_warning": "Turn off the battery warning",
         "disable_buttons": "Turn off the plus/minus buttons",
+		"disable_slider": "Disable slider interaction",
         "disable_all_buttons": "Turn off all buttons",
         "show_temperature_control": "Show temperature control",
         "collapsible_controls": "Collapsible controls",

--- a/src/localize/languages/es.json
+++ b/src/localize/languages/es.json
@@ -14,6 +14,7 @@
         "disable_menu": "Deshabilitar menú",
         "disable_battery_warning": "Deshabilitar alerta de batería",
         "disable_buttons": "Deshabilitar botones más/menos",
+		"disable_slider": "Deshabilitar deslizador",
         "show_temperature_control": "Mostrar control de temperatura",
         "collapsible_controls": "Controles plegables",
         "show_current_as_primary": "Mostrar temperatura actual como principal",

--- a/src/localize/languages/fi.json
+++ b/src/localize/languages/fi.json
@@ -14,6 +14,7 @@
         "disable_menu": "Poista valikko käytöstä",
         "disable_battery_warning": "Poista akun varoitus käytöstä",
         "disable_buttons": "Poista plus/miinus -painikkeet käytöstä",
+		"disable_slider": "Poista liukusäädin käytöstä",
         "show_temperature_control": "Näytä lämpötilan säätö",
         "collapsible_controls": "Kokoon taittuvat säätimet",
         "show_current_as_primary": "Näytä nykyinen lämpötila ensisijaisena",

--- a/src/localize/languages/fr.json
+++ b/src/localize/languages/fr.json
@@ -14,6 +14,7 @@
         "disable_menu": "Désactiver le menu",
         "disable_battery_warning": "Désactiver l'avertissement de batterie",
         "disable_buttons": "Désactiver les boutons plus/moins",
+		"disable_slider": "Désactiver le curseur",
         "show_temperature_control": "Afficher le contrôle de température",
         "collapsible_controls": "Contrôles pliables",
         "show_current_as_primary": "Afficher la température actuelle comme principale",

--- a/src/localize/languages/gl.json
+++ b/src/localize/languages/gl.json
@@ -11,6 +11,7 @@
         "disable_menu": "Desactivar menú",
         "disable_battery_warning": "Desactivar alerta de batería",
         "disable_buttons": "Desactivar botóns máis/menos",
+		"disable_slider": "Desactivar desprazador",
         "show_temperature_control": "Mostrar control de temperatura",
         "collapsible_controls": "Controis pregables",
         "disable_connection_lost_warning": "Desactivar aviso de perda de conexión",

--- a/src/localize/languages/hr.json
+++ b/src/localize/languages/hr.json
@@ -13,6 +13,7 @@
         "disable_menu": "Isključi prikaz izbornika",
         "disable_battery_warning": "Isključi upozorenje baterije",
         "disable_buttons": "Isključi prikaz plus/minus gumbi",
+		"disable_slider": "Isključi klizni regulator",
         "show_current_as_primary": "Prikaži trenutnu temperaturu kao primarnu",
         "show_secondary": "Prikaži sekundarne informacije",
         "prevent_interaction_on_scroll": "Spriječi interakciju pri pomicanju",

--- a/src/localize/languages/hu.json
+++ b/src/localize/languages/hu.json
@@ -14,6 +14,7 @@
         "disable_menu": "Menü letiltása",
         "disable_battery_warning": "Akkumulátor figyelmeztetés letiltása",
         "disable_buttons": "Plusz/mínusz gombok letiltása",
+		"disable_slider": "Csúszka letiltása",
         "show_temperature_control": "Hőmérséklet-szabályzó megjelenítése",
         "collapsible_controls": "Összecsukható vezérlők",
         "show_current_as_primary": "Jelenlegi hőmérséklet megjelenítése elsődlegesként",

--- a/src/localize/languages/it.json
+++ b/src/localize/languages/it.json
@@ -14,6 +14,7 @@
         "disable_menu": "Disabilita menu",
         "disable_battery_warning": "Disabilita avviso batteria",
         "disable_buttons": "Disabilita pulsanti più/meno",
+		"disable_slider": "Disabilita cursore",
         "show_temperature_control": "Mostra controllo temperatura",
         "collapsible_controls": "Controlli comprimibili",
         "show_current_as_primary": "Mostra temperatura attuale come principale",

--- a/src/localize/languages/kr.json
+++ b/src/localize/languages/kr.json
@@ -10,6 +10,7 @@
         "disable_menu": "메뉴 표시 하지 않기",
         "disable_battery_warning": "배터리 경고 표시 하지 않기",
         "disable_buttons": "온도 조절 버튼 표시 하지 않기",
+		"disable_slider": "슬라이더 조작 비활성화",
         "disable_humidity": "습도 표시 끄기",
         "show_current_as_primary": "현재 온도를 기본으로 표시",
         "show_secondary": "보조 정보 표시",

--- a/src/localize/languages/lt.json
+++ b/src/localize/languages/lt.json
@@ -10,6 +10,7 @@
         "disable_menu": "Išjungti meniu",
         "disable_battery_warning": "Išjungti baterijos pranešimą",
         "disable_buttons": "Nerodyti plius/minus mygtukų",
+		"disable_slider": "Išjungti slankiklį",
         "disable_humidity": "Išjungti drėgmės rodymą",
         "show_temperature_control": "Rodyti temperatūros valdymą",
         "collapsible_controls": "Sulankstomi valdikliai",

--- a/src/localize/languages/lv.json
+++ b/src/localize/languages/lv.json
@@ -14,6 +14,7 @@
         "disable_menu": "Atspējot izvēlni",
         "disable_battery_warning": "Atspējot baterijas brīdinājumu",
         "disable_buttons": "Atspējot plus/mīnus pogas",
+		"disable_slider": "Atspējot slīdni",
         "show_temperature_control": "Rādīt temperatūras kontroli",
         "collapsible_controls": "Salocāmas vadīklas",
         "show_current_as_primary": "Rādīt pašreizējo temperatūru kā galveno",

--- a/src/localize/languages/nl.json
+++ b/src/localize/languages/nl.json
@@ -14,6 +14,7 @@
         "disable_menu": "Menu uitschakelen",
         "disable_battery_warning": "Batterijwaarschuwing uitschakelen",
         "disable_buttons": "Plus/min-knoppen uitschakelen",
+		"disable_slider": "Schuifregelaar uitschakelen",
         "show_temperature_control": "Temperatuurregeling tonen",
         "collapsible_controls": "Inklapbare bedieningselementen",
         "show_current_as_primary": "Toon huidige temperatuur als primair",

--- a/src/localize/languages/no.json
+++ b/src/localize/languages/no.json
@@ -14,6 +14,7 @@
         "disable_menu": "Deaktiver meny",
         "disable_battery_warning": "Deaktiver batterivarsel",
         "disable_buttons": "Deaktiver pluss/minus knapper",
+		"disable_slider": "Deaktiver skyvekontroll",
         "show_temperature_control": "Vis temperaturkontroll",
         "collapsible_controls": "Sammenleggbare kontroller",
         "show_current_as_primary": "Vis nåværende temperatur som primær",

--- a/src/localize/languages/pl.json
+++ b/src/localize/languages/pl.json
@@ -15,6 +15,7 @@
         "disable_menu": "Wyłącz menu",
         "disable_battery_warning": "Wyłącz ostrzeżenie o baterii",
         "disable_buttons": "Wyłącz przyciski plus/minus",
+		"disable_slider": "Wyłącz suwak",
         "disable_all_buttons": "Wyłącz wszystkie przyciski",
         "show_temperature_control": "Pokaż suwak temperatury",
         "collapsible_controls": "Rozwijane menu ustawień",

--- a/src/localize/languages/pt-BR.json
+++ b/src/localize/languages/pt-BR.json
@@ -13,6 +13,7 @@
         "disable_menu": "Desabilitar menu",
         "disable_battery_warning": "Desabilitar aviso de bateria",
         "disable_buttons": "Desabilitar botões mais/menos",
+		"disable_slider": "Desabilitar controle deslizante",
         "show_current_as_primary": "Mostrar temperatura atual como principal",
         "show_secondary": "Mostrar informações secundárias",
         "prevent_interaction_on_scroll": "Prevenir interação ao rolar",

--- a/src/localize/languages/pt.json
+++ b/src/localize/languages/pt.json
@@ -14,6 +14,7 @@
         "disable_menu": "Desativar menu",
         "disable_battery_warning": "Desativar aviso de bateria",
         "disable_buttons": "Desativar botões de mais/menos",
+		"disable_slider": "Desativar controlo deslizante",
         "show_temperature_control": "Mostrar controlo de temperatura",
         "collapsible_controls": "Controlos recolhíveis",
         "show_current_as_primary": "Mostrar temperatura atual como principal",

--- a/src/localize/languages/ro.json
+++ b/src/localize/languages/ro.json
@@ -14,6 +14,7 @@
         "disable_menu": "Dezactivează meniul",
         "disable_battery_warning": "Dezactivează avertizarea bateriei",
         "disable_buttons": "Dezactivează butoanele plus/minus",
+		"disable_slider": "Dezactivează glisorul",
         "show_temperature_control": "Afișează controlul temperaturii",
         "collapsible_controls": "Controale pliabile",
         "show_current_as_primary": "Afișează temperatura curentă ca principală",

--- a/src/localize/languages/ru.json
+++ b/src/localize/languages/ru.json
@@ -14,6 +14,7 @@
         "disable_menu": "Отключить меню",
         "disable_battery_warning": "Отключить предупреждение о разряде батареи",
         "disable_buttons": "Отключить кнопку плюс/минус",
+		"disable_slider": "Отключить ползунок",
         "show_temperature_control": "Показать управление температурой",
         "collapsible_controls": "Сворачиваемые элементы управления",
         "show_current_as_primary": "Показывать текущую температуру как основную",

--- a/src/localize/languages/sk.json
+++ b/src/localize/languages/sk.json
@@ -14,6 +14,7 @@
         "disable_menu": "Zakázať menu",
         "disable_battery_warning": "Zakázať upozornenie na batériu",
         "disable_buttons": "Zakázať plus/mínus tlačidlá",
+		"disable_slider": "Zakázať posuvník",
         "show_temperature_control": "Zobraziť ovládanie teploty",
         "collapsible_controls": "Skladateľné ovládanie",
         "show_current_as_primary": "Zobraziť aktuálnu teplotu ako hlavnú",

--- a/src/localize/languages/sl.json
+++ b/src/localize/languages/sl.json
@@ -14,6 +14,7 @@
         "disable_menu": "Onemogoči meni",
         "disable_battery_warning": "Onemogoči opozorilo o bateriji",
         "disable_buttons": "Onemogoči gumbe plus/minus",
+		"disable_slider": "Onemogoči drsnik",
         "show_temperature_control": "Prikaži nadzor temperature",
         "collapsible_controls": "Zložljivi kontrolniki",
         "show_current_as_primary": "Prikaži trenutno temperaturo kot primarno",

--- a/src/localize/languages/sv.json
+++ b/src/localize/languages/sv.json
@@ -14,6 +14,7 @@
         "disable_menu": "Inaktivera meny",
         "disable_battery_warning": "Inaktivera batterivarning",
         "disable_buttons": "Inaktivera plus/minus knappar",
+		"disable_slider": "Inaktivera skjutreglage",
         "show_temperature_control": "Visa temperaturkontroll",
         "collapsible_controls": "Ihopfällbara kontroller",
         "show_current_as_primary": "Visa aktuell temperatur som primär",

--- a/src/localize/languages/tr.json
+++ b/src/localize/languages/tr.json
@@ -14,6 +14,7 @@
         "disable_menu": "Menüyü devre dışı bırak",
         "disable_battery_warning": "Pil uyarısını devre dışı bırak",
         "disable_buttons": "Artı/eksi düğmelerini devre dışı bırak",
+		"disable_slider": "Kaydırıcıyı devre dışı bırak",
         "show_temperature_control": "Sıcaklık kontrolünü göster",
         "collapsible_controls": "Daraltılabilir kontroller",
         "show_current_as_primary": "Mevcut sıcaklığı birincil olarak göster",

--- a/src/localize/languages/uk.json
+++ b/src/localize/languages/uk.json
@@ -14,6 +14,7 @@
         "disable_menu": "Прибрати меню",
         "disable_battery_warning": "Прибрати попередження про акумулятор",
         "disable_buttons": "Прибрати кнопки плюс/мінус",
+		"disable_slider": "Вимкнути повзунок"
         "show_temperature_control": "Показати контроль температури",
         "collapsible_controls": "Згортані елементи керування",
         "show_current_as_primary": "Показувати поточну температуру як основну",

--- a/src/localize/languages/uk.json
+++ b/src/localize/languages/uk.json
@@ -14,7 +14,7 @@
         "disable_menu": "Прибрати меню",
         "disable_battery_warning": "Прибрати попередження про акумулятор",
         "disable_buttons": "Прибрати кнопки плюс/мінус",
-		"disable_slider": "Вимкнути повзунок"
+		"disable_slider": "Вимкнути повзунок",
         "show_temperature_control": "Показати контроль температури",
         "collapsible_controls": "Згортані елементи керування",
         "show_current_as_primary": "Показувати поточну температуру як основну",

--- a/src/normal/climate-card.ts
+++ b/src/normal/climate-card.ts
@@ -227,6 +227,7 @@ export class BetterThermostatUINormalCard
 
     this._config = {
       disable_buttons: true,
+	  disable_slider: false,
       ...config,
     };
   }
@@ -624,6 +625,7 @@ export class BetterThermostatUINormalCard
           .max=${this._max}
           .step=${this._step}
           .current=${stateObj.attributes.current_temperature}
+		  .disabled=${this._config!.disable_slider}
           @value-changed=${this._valueChanged}
           @value-changing=${this._valueChanging}
         >

--- a/src/normal/climate-card.ts
+++ b/src/normal/climate-card.ts
@@ -606,6 +606,7 @@ export class BetterThermostatUINormalCard
           .max=${this._max}
           .step=${this._step}
           .current=${stateObj.attributes.current_temperature}
+		  .disabled=${this._config!.disable_slider}
           @low-changed=${this._lowChanged}
           @low-changing=${this._lowChanging}
           @high-changed=${this._highChanged}

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -19,6 +19,7 @@ export type SharedBtCardConfig = {
   show_current_as_primary?: boolean;
   show_secondary?: boolean;
   disable_buttons?: boolean;
+  disable_slider?: boolean;
   disable_all_buttons?: boolean;
   disable_menu?: boolean;
   prevent_interaction_on_scroll?: boolean;
@@ -44,6 +45,7 @@ export const sharedBtConfigStruct = object({
   show_current_as_primary: optional(boolean()),
   show_secondary: optional(boolean()),
   disable_buttons: optional(boolean()),
+  disable_slider: optional(boolean()),
   disable_all_buttons: optional(boolean()),
   disable_menu: optional(boolean()),
   prevent_interaction_on_scroll: optional(boolean()),

--- a/src/shared/editor-schema.ts
+++ b/src/shared/editor-schema.ts
@@ -27,6 +27,7 @@ export const CLIMATE_LABELS: string[] = [
   "show_current_as_primary",
   "show_secondary",
   "disable_buttons",
+  "disable_slider",
   "disable_all_buttons",
   "disable_menu",
   "prevent_interaction_on_scroll",
@@ -166,6 +167,7 @@ export const computeInteractionSection = (): HaFormSchema =>
         name: "",
         schema: [
           { name: "disable_buttons", selector: { boolean: {} } },
+		  { name: "disable_slider", selector: { boolean: {} } },
           { name: "disable_all_buttons", selector: { boolean: {} } },
           { name: "disable_menu", selector: { boolean: {} } },
           { name: "prevent_interaction_on_scroll", selector: { boolean: {} } },


### PR DESCRIPTION
## Description
Adds a `disable_slider` configuration option to allow users to disable touch/click interactions on the target temperature slider.

## Changes
- Added `disable_slider` boolean option to card configuration schema, types, and editor.
- Bound `.disabled` property of the slider element to `this._config.disable_slider`.
- Added localized translations for `disable_slider` across all language files.

## Testing
1. Set `disable_slider: true` in the Lovelace card YAML or card editor.
2. Verified that the slider UI element is visually disabled and ignores touch/click inputs.
3. Verified default functionality (`disable_slider: false`) remains unchanged.

<img width="990" height="1057" alt="disable_slider" src="https://github.com/user-attachments/assets/1bff9d1d-9ae4-42bc-88f7-a8dabde62f2f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option to disable temperature slider interaction in the climate card.
  - The slider now respects the configured setting and remains enabled by default.
- **Localization**
  - Added translations for the new slider-disable option across supported languages, including Bulgarian, Chinese, French, German, Spanish, and many others.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->